### PR TITLE
docs(man): fix overflowing text in examples

### DIFF
--- a/data/man/corecollector_conf.5.scd
+++ b/data/man/corecollector_conf.5.scd
@@ -1,15 +1,17 @@
 corecollector.conf(5)
 
 # NAME
-corecollector.conf - configuration for corecollector, a coredump collector
+
+corecollector.conf - configuration for corecollector
 
 # DESCRIPTION
+
 The *corecollector.conf* file is used to configure corecollector. As of now it
-supports the following, not case sensitive, keys:
+supports the following, not case sensitive, keywords:
 
 *compression*
 	This sets what compression algorithm should be used for compression.
-	As of now none are supported.
+	Zlib is supported, while no compression is the default.
 
 *maxSize*
 	This sets the maximum size (in KByte) of a coredump. If the coredump
@@ -33,32 +35,38 @@ supports the following, not case sensitive, keys:
 	targetPath may grow to before corehelper starts deleting old coredumps.
 
 # FILES
-corecollector.conf	configuration for corecollector, a coredump collector
+
+_/etc/corecollector/corecollector.conf_++
+	Configuration for corecollector, a coredump collector.
 
 # EXAMPLES
-\# What compression to use for coredumps.
-\# Available choices:
-compression = none
-\# The maximum size of coredumps.
-\# Unset or set to 0 to set no size limit.
-\# Measured in KByte, must be whole numbers.
-maxSize = 0
-\# The path to save coredumps to.
-targetPath = /var/lib/corecollector
-\# Where to log to. Pass /dev/null to only log to syslog
-logPath = /var/log/corecollector.log
-\# Enable debugging
-enableDebug = false
-\# The maximum size of the coredumpdir.
-\# Unset or set to 0 to set no size limit.
-\# Measured in KByte, must be whole numbers.
+
+\# What compression to use for coredumps.++
+\# Available choices: none zlib++
+compression = none++
+\# The maximum size of coredumps.++
+\# Unset or set to 0 to set no size limit.++
+\# Measured in KByte, must be whole numbers.++
+maxSize = 0++
+\# The path to save coredumps to.++
+targetPath = /var/lib/corecollector++
+\# Where to log to. Pass /dev/null to only log to syslog++
+logPath = /var/log/corecollector.log++
+\# Enable debugging++
+enableDebug = false++
+\# The maximum size of the coredumpdir.++
+\# Unset or set to 0 to set no size limit.++
+\# Measured in KByte, must be whole numbers.++
 maxDirSize = 0
 
 # SEE ALSO
+
 *corectl*(1)
 
 # BUGS
+
 See bugs at https://github.com/Cogitri/corecollector
 
 # AUTHORS
+
 Rasmus Thomsen

--- a/data/man/corectl.1.scd
+++ b/data/man/corectl.1.scd
@@ -5,6 +5,7 @@ corectl(1)
 corectl - User binary for interacting with corecollector
 
 # SYNOPSIS
+
 *corectl* [options...] [command]
 
 # DESCRIPTION
@@ -13,6 +14,7 @@ Corectl allows you to interact with previously collected coredumps, e.g.
 by showing additional information or opening the coredump in a debugger.
 
 # OPTIONS
+
 The corectl application accepts the following command line parameters:
 
 *-h, --help*
@@ -27,6 +29,7 @@ The corectl application accepts the following command line parameters:
 	trace log messages.
 
 # COMMANDS
+
 The corectl application also expects users to supply one of the following commands:
 
 *backtrace* [ID]
@@ -46,10 +49,13 @@ The corectl application also expects users to supply one of the following comman
 	List all available coredumps.
 
 # SEE ALSO
+
 *corecollector.conf*(5)
 
 # BUGS
+
 See bugs at https://github.com/Cogitri/corecollector
 
 # AUTHOR
+
 Rasmus Thomsen


### PR DESCRIPTION
Sorry, in advance, if I did not follow the correct style.

This fixes overflowing text in the examples section of the corecollector.conf man page. In addition, there are a few misc fixes.